### PR TITLE
Fix code scanning alert no. 5: Incorrect conversion between integer types

### DIFF
--- a/examples/chaincode/chaintool/example02/src/chaincode/chaincode_example02.go
+++ b/examples/chaincode/chaintool/example02/src/chaincode/chaincode_example02.go
@@ -112,7 +112,7 @@ func (t *ChaincodeExample) CheckBalance(stub *shim.ChaincodeStub, param *example
 	}
 
 	fmt.Printf("Query Response: %d\n", val)
-	return &example02.BalanceResult{Balance: *proto.Int32(int32(val))}, nil
+	return &example02.BalanceResult{Balance: *proto.Int32(val)}, nil
 }
 
 func main() {
@@ -144,6 +144,6 @@ func (t *ChaincodeExample) GetState(stub *shim.ChaincodeStub, entity string) (in
 		return 0, errors.New("Entity not found")
 	}
 
-	val, _ := strconv.Atoi(string(bytes))
-	return val, nil
+	val64, _ := strconv.ParseInt(string(bytes), 10, 32)
+	return int(val64), nil
 }


### PR DESCRIPTION
Fixes [https://github.com/vishmeduri/fabric/security/code-scanning/5](https://github.com/vishmeduri/fabric/security/code-scanning/5)

To fix the problem, we need to ensure that the value parsed from the string is within the bounds of `int32` before performing the conversion. This can be achieved by using `strconv.ParseInt` with a specified bit size of 32, which directly parses the string into an `int32` value. Alternatively, we can add bounds checks to ensure the value fits within the `int32` range before converting it.

The best way to fix the problem without changing existing functionality is to use `strconv.ParseInt` with a bit size of 32. This approach is straightforward and avoids the need for additional bounds checks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
