### PR TITLE
Fix code scanning alert no. 4: Size computation for allocation may overflow

### DIFF
--- a/core/chaincode/platforms/golang/hash.go
+++ b/core/chaincode/platforms/golang/hash.go
@@ -67,6 +67,9 @@ func hashFilesInDir(rootDir string, dir string, hash []byte, tw *tar.Writer) ([]
 			return hash, err
 		}
 
+		if len(hash) > (int(^uint(0) >> 1) - len(buf)) {
+			return hash, errors.New("size computation for allocation may overflow")
+		}
 		newSlice := make([]byte, len(hash)+len(buf))
 		copy(newSlice[len(buf):], hash[:])
 		//hash = md5.Sum(newSlice)


### PR DESCRIPTION
Fixes [https://github.com/vishmeduri/fabric/security/code-scanning/4](https://github.com/vishmeduri/fabric/security/code-scanning/4)

To fix the problem, we need to ensure that the size computation for the allocation does not overflow. This can be achieved by adding a guard to check the size of `buf` before performing the addition. If the size of `buf` is too large, we should return an error to prevent the overflow.

The best way to fix the problem without changing existing functionality is to add a check to ensure that the sum of `len(hash)` and `len(buf)` does not exceed the maximum value for an `int`. If it does, we return an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
